### PR TITLE
Review of OpenBSD's packer.json

### DIFF
--- a/openbsd-6.4/docroot/autoinstall.conf
+++ b/openbsd-6.4/docroot/autoinstall.conf
@@ -1,0 +1,11 @@
+keyboard layout = us
+System hostname = openbsd66
+Password for root = SAME_AS_PACKER_DOT_JSON
+ntpd = yes
+X Window System = no
+Allow root ssh = yes
+Use (W)hole disk = W
+URL to autopartitioning template for disklabel = https://YOUR_PRIVATE_REPO/disklabel.txt
+Location of sets = cd0
+Continue without verification = yes
+timezone = Europe/Zurich

--- a/openbsd-6.4/packer.json
+++ b/openbsd-6.4/packer.json
@@ -1,68 +1,51 @@
 {
-      "variables": {
-          "image_url": "http://ftp.fr.openbsd.org/pub/OpenBSD/6.4/amd64/install64.iso",
-          "image_checksum_url": "http://ftp.fr.openbsd.org/pub/OpenBSD/6.4/amd64/SHA256",
-          "image_checksum_type": "sha256",
-          "image_name": "openbsd-6.4",
-          "ssh_password": "{{uuid}}"
-      },
+    "variables": {
+        "image_url": "https://cdn.openbsd.org/pub/OpenBSD/6.6/amd64/install66.iso",
+        "image_checksum_url": "https://cdn.openbsd.org/pub/OpenBSD/6.6/amd64/SHA256",
+        "image_checksum_type": "sha256",
+        "image_name": "openbsd-6.6",
+        "ssh_password": "SAME_AS_AUTOINSTALL"
+    },
     "builders": [
         {
             "type": "qemu",
-            "iso_url": "{{user `image_url`}}",
-            "iso_checksum_url": "{{user `image_checksum_url`}}",
-            "iso_checksum_type": "{{user `image_checksum_type`}}",
-            "shutdown_command": "/sbin/halt -p",
+            "cpus": 2,
+            "disk_interface": "virtio",
             "disk_size": 12000,
             "format": "qcow2",
-            "ssh_username": "root",
+            "http_directory": "docroot/",
+            "iso_checksum_type": "{{user `image_checksum_type`}}",
+            "iso_checksum_url": "{{user `image_checksum_url`}}",
+            "iso_url": "{{user `image_url`}}",
+            "shutdown_command": "/sbin/halt -p",
+            "ssh_timeout": "10m",
             "ssh_password": "{{user `ssh_password`}}",
-            "vm_name": "{{user `image_name`}}.qcow2",
+            "ssh_username": "root",
             "use_default_display": true,
-            "disk_interface": "virtio",
-            "vnc_port_min": 5910,
+            "vm_name": "{{user `image_name`}}.qcow2",
             "vnc_port_max": 5910,
+            "vnc_port_min": 5910,
             "boot_wait": "30s",
             "boot_command": [
-                "I<enter><wait>",
-                "<enter><wait>",
-                "openbsd<enter><wait>",
-                "vio0<enter><wait>",
-                "dhcp<enter><wait>",
-                "none<enter><wait>",
-                "<enter><wait>",
-                "<enter><wait>",
-                "{{user `ssh_password`}}<enter><wait>",
-                "{{user `ssh_password`}}<enter><wait>",
-                "yes<enter><wait>",
-                "no<enter><wait>",
-                "no<enter><wait>",
-                "no<enter><wait>",
-                "yes<enter><wait>",
-                "Europe/Zurich<enter><wait>",
-                "sd0<enter><wait>",
-                "whole<enter><wait>",
-                "a<enter><wait10>",
-                "cd<enter><wait>",
-                "6.4/amd64<enter><wait>",
-                "done<enter><wait>",
-                "yes<enter><wait60>",
-                "done<enter><wait10>",
-                "r<enter><wait>"
+                "http://{{ .HTTPIP }}:{{ .HTTPPort }}/autoinstall.conf<enter>",
+                "I<enter>"
             ]
         }
     ],
     "provisioners": [
-        {"type": "file",
-         "source": "openbsd-cloud-init/cloud-init.pl",
-         "destination": "/usr/local/libdata/cloud-init.pl"
+        {
+            "type": "file",
+            "source": "openbsd-cloud-init/cloud-init.pl",
+            "destination": "/usr/local/libdata/cloud-init.pl"
         },
-        {"type": "shell",
-         "inline": ["perl /usr/local/libdata/cloud-init.pl deploy"]
+        {
+            "type": "shell",
+            "inline": ["perl /usr/local/libdata/cloud-init.pl deploy"]
         },
-        {"type": "file",
-         "source": "{{user `image_name`}}/hostname.vio0",
-         "destination": "/etc/hostname.vio0"
+        {
+            "type": "file",
+            "source": "{{user `image_name`}}/hostname.vio0",
+            "destination": "/etc/hostname.vio0"
         }
     ]
 }

--- a/openbsd-6.4/packer.json
+++ b/openbsd-6.4/packer.json
@@ -13,7 +13,7 @@
             "disk_interface": "virtio",
             "disk_size": 12000,
             "format": "qcow2",
-            "http_directory": "docroot/",
+            "http_directory": "{{ user `image_name`}}/docroot/",
             "iso_checksum_type": "{{user `image_checksum_type`}}",
             "iso_checksum_url": "{{user `image_checksum_url`}}",
             "iso_url": "{{user `image_url`}}",
@@ -25,10 +25,10 @@
             "vm_name": "{{user `image_name`}}.qcow2",
             "vnc_port_max": 5910,
             "vnc_port_min": 5910,
-            "boot_wait": "30s",
+            "boot_wait": "60s",
             "boot_command": [
-                "http://{{ .HTTPIP }}:{{ .HTTPPort }}/autoinstall.conf<enter>",
-                "I<enter>"
+                "A<enter>",
+                "http://{{ .HTTPIP }}:{{ .HTTPPort }}/autoinstall.conf<enter>"
             ]
         }
     ],


### PR DESCRIPTION
This is a proposal to use `autoinstall(8)` instead of the basic key input.
This will also propose some useful tricks for usage with Exoscale :
 - setting `cpus` >= 2 will allow the installer to set a multi-core kernel (ie. `GENERIC.MP`)
 - autoinstall(8) will take care of the installation settings, make it more robust than keyboard inputs
 - update to OpenBSD 6.6 (current release)
 - autoinstall is able to retrieve a disklabel format file
 - do some reformatting of the packer JSON file

Also, please take note that the SSH password for the image is not synced between `autoinstall.conf` and `packer.json`. You'll have to set it before using successfully this image.